### PR TITLE
Primera versión (sin probar) de la API para comunicar el módulo Rust

### DIFF
--- a/gamey/src/game_server/action.rs
+++ b/gamey/src/game_server/action.rs
@@ -1,0 +1,84 @@
+use crate::{Coordinates, GameStatus, GameY, GameYError, Movement, PlayerId, YEN, game_server::{game_error::ErrorResponse, version::check_api_version}};
+use axum::{
+    Json,
+    extract::{Path},
+};
+use serde::{Deserialize, Serialize};
+
+/// Parámetros extraidos de la URL.
+#[derive(Deserialize)]
+pub struct ActionParams {
+    /// Versión de la API (e.g., "v1").
+    api_version: String,
+    /// Identificador de un jugador dentro de una partida.
+    player_id: u32,
+}
+
+/// Cuerpo de las peticiones HTTP para realizar una jugada
+#[derive(Deserialize)]
+pub struct PlaceRequest {
+    /// Estado actual del juego
+    game: YEN,
+    /// Coordenadas de la jugada
+    coords: Coordinates
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct MoveResponse {
+    /// Versión de la API usada para la petición.
+    pub api_version: String,
+    /// EL jugador que ha realizado la jugada.
+    pub player_id: u32,
+    /// El resultado de la jugada.
+    pub state: MovementState
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum MovementState {
+    Valid, Invalid, Win
+}
+
+/// Comprueba si la acción realizada por el jugador es válida o no, y si es para ganar.
+pub async fn place(
+    Path(params) : Path<ActionParams>,
+    Json(place): Json<PlaceRequest>
+) -> Result<Json<MoveResponse>, Json<ErrorResponse>> {
+    // Comprueba la versión de la API
+    check_api_version(&params.api_version)?;
+    let mut game_y = match GameY::try_from(place.game) {
+        Ok(game) => game,
+        Err(err) => {
+            return Err(Json(ErrorResponse::error(
+                &format!("Invalid YEN format: {}", err),
+                Some(params.api_version)
+            )));
+        }
+    };
+    // Determina si el movimiento realizado es válido o no
+    let state: MovementState = match game_y.add_move(Movement::Placement {
+            player: PlayerId::new(params.player_id),
+            coords: place.coords,
+    }) {
+        Ok(()) => {
+            match game_y.status() {
+                GameStatus::Finished { .. } => MovementState::Win,
+                GameStatus::Ongoing { .. } => MovementState::Valid
+            }
+        }
+        Err(GameYError::Occupied { .. }) => { 
+            MovementState::Invalid
+        }
+        Err(_e) => {
+            return Err(Json(ErrorResponse::error(
+                "Unkown error.",
+                Some(params.api_version),
+            )));
+        }
+    };
+    let response = MoveResponse {
+        api_version: params.api_version,
+        player_id: params.player_id,
+        state
+    };
+    Ok(Json(response))
+}

--- a/gamey/src/game_server/game_error.rs
+++ b/gamey/src/game_server/game_error.rs
@@ -1,0 +1,86 @@
+use axum::{Json, http::StatusCode, response::IntoResponse};
+use serde::{Deserialize, Serialize};
+
+/// A structured error response returned by the game server API.
+///
+/// This type is serialized to JSON and returned when API requests fail.
+/// It includes context about which API version were involved.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct ErrorResponse {
+    /// The API version that was requested, if available.
+    pub api_version: Option<String>,
+    /// A human-readable error message describing what went wrong.
+    pub message: String,
+}
+
+impl ErrorResponse {
+    /// Creates a new error response with the given message and optional context.
+    ///
+    /// # Arguments
+    /// * `message` - A description of the error
+    /// * `api_version` - The API version from the request, if known
+    pub fn error(message: &str, api_version: Option<String>) -> Self {
+        Self {
+            api_version,
+            message: message.to_string(),
+        }
+    }
+}
+
+impl IntoResponse for ErrorResponse {
+    fn into_response(self) -> axum::response::Response {
+        (StatusCode::BAD_REQUEST, Json(self)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_with_all_fields() {
+        let err = ErrorResponse::error(
+            "Something went wrong",
+            Some("v1".to_string())
+        );
+        assert_eq!(err.message, "Something went wrong");
+        assert_eq!(err.api_version, Some("v1".to_string()));
+    }
+
+    #[test]
+    fn test_error_with_no_context() {
+        let err = ErrorResponse::error("Generic error", None);
+        assert_eq!(err.message, "Generic error");
+        assert_eq!(err.api_version, None);
+    }
+
+    #[test]
+    fn test_error_with_partial_context() {
+        let err = ErrorResponse::error("Version error", Some("v2".to_string()));
+        assert_eq!(err.message, "Version error");
+        assert_eq!(err.api_version, Some("v2".to_string()));
+    }
+
+    #[test]
+    fn test_serialize() {
+        let err = ErrorResponse::error("Test error", Some("v1".to_string()));
+        let json = serde_json::to_string(&err).unwrap();
+        assert!(json.contains("\"message\":\"Test error\""));
+        assert!(json.contains("\"api_version\":\"v1\""));
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let json = r#"{"api_version":"v1","message":"error msg"}"#;
+        let err: ErrorResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(err.message, "error msg");
+        assert_eq!(err.api_version, Some("v1".to_string()));
+    }
+
+    #[test]
+    fn test_clone() {
+        let err = ErrorResponse::error("Clone test", Some("v1".to_string()));
+        let cloned = err.clone();
+        assert_eq!(err, cloned);
+    }
+}

--- a/gamey/src/game_server/mod.rs
+++ b/gamey/src/game_server/mod.rs
@@ -1,0 +1,43 @@
+pub mod game_error;
+pub mod version;
+pub mod action;
+
+use crate::{GameYError, game_server::action::place};
+
+use tower_http::cors::{Any, CorsLayer};
+use axum::http::Method;
+
+/// Crea el servidor del juego
+fn create_router() -> axum::Router {
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([Method::GET, Method::POST])
+        .allow_headers(Any);
+
+
+    axum::Router::new()
+        .route("/{api_version}/game/place/{player_id}", axum::routing::post(place))
+        .layer(cors) 
+}
+
+/// Lanza el servidor del juego
+pub async fn run_game_server(port: u16) -> Result<(), GameYError> {
+    let app = create_router();
+
+    let addr = format!("0.0.0.0:{}", port);
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .map_err(|e| GameYError::ServerError {
+            message: format!("Failed to bind to {}: {}", addr, e),
+        })?;
+
+    println!("Server mode: Listening on http://{}", addr);
+    axum::serve(listener, app)
+        .await
+        .map_err(|e| GameYError::ServerError {
+            message: format!("Server error: {}", e),
+        })?;
+
+    Ok(())
+}

--- a/gamey/src/game_server/version.rs
+++ b/gamey/src/game_server/version.rs
@@ -1,0 +1,58 @@
+use crate::game_server::game_error::ErrorResponse;
+
+/// Versión actual de la API.
+pub const SUPPORTED_VERSION: &str = "v1";
+
+/// Valida la versión de la API.
+pub fn check_api_version(version: &str) -> Result<(), ErrorResponse> {
+    if version != SUPPORTED_VERSION {
+        Err(ErrorResponse::error(
+            &format!(
+                "Unsupported API version: {}. Supported version is {}",
+                version, SUPPORTED_VERSION
+            ),
+            Some(version.to_string()),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_supported_version() {
+        assert!(check_api_version("v1").is_ok());
+    }
+
+    #[test]
+    fn test_unsupported_version_v2() {
+        let result = check_api_version("v2");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Unsupported API version"));
+        assert!(err.message.contains("v2"));
+        assert_eq!(err.api_version, Some("v2".to_string()));
+    }
+
+    #[test]
+    fn test_unsupported_version_empty() {
+        let result = check_api_version("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_unsupported_version_random() {
+        let result = check_api_version("random_version");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.api_version, Some("random_version".to_string()));
+    }
+
+    #[test]
+    fn test_supported_version_constant() {
+        assert_eq!(SUPPORTED_VERSION, "v1");
+    }
+}

--- a/gamey/src/lib.rs
+++ b/gamey/src/lib.rs
@@ -34,6 +34,7 @@ pub mod core;
 pub mod gamey_error;
 pub mod notation;
 pub mod bot_server;
+pub mod game_server;
 pub use bot::*;
 pub use cli::*;
 pub use core::*;


### PR DESCRIPTION
Se ha creado una versión inicial de la API con un método para validar una jugada, de tal manera que se indica si la jugada es válida, inválida o ganadora.